### PR TITLE
Fixed a bug with the spawn of the commander's beacon

### DIFF
--- a/mods/battle-royale/hook/lua/aibrain.lua
+++ b/mods/battle-royale/hook/lua/aibrain.lua
@@ -344,7 +344,7 @@ AIBrain = Class(oldAIBrain) {
 
             --- change (3)
             if TargetArmy then
-                CreateCommanderBeacon(units, unpack(ACUDeathCoordinates:GetCoords()))
+                CreateCommanderBeacon(units, unpack(ACUDeathCoordinates:GetCoords(selfIndex)))
             else
                 local tokill = self:GetListOfUnits(categories.ALLUNITS - categories.WALL, false)
                 if tokill and not table.empty(tokill) then

--- a/mods/battle-royale/hook/lua/defaultunits.lua
+++ b/mods/battle-royale/hook/lua/defaultunits.lua
@@ -3,7 +3,8 @@ local ACUDeathCoordinates = import('/mods/battle-royale/modules/sim/ACUInfo.lua'
 
 ACUUnit = Class(oldACU) {
     OnKilled = function(self, instigator, type, overkillRatio)
-        ACUDeathCoordinates:SetCoords(unpack(self:GetPosition()))
+        local selfIndex = self:GetAIBrain():GetArmyIndex()
+        ACUDeathCoordinates:SetCoords(selfIndex, unpack(self:GetPosition()))
         oldACU.OnKilled(self, instigator, type, overkillRatio)
     end
 }

--- a/mods/battle-royale/merge/units/uac1301.bp
+++ b/mods/battle-royale/merge/units/uac1301.bp
@@ -15,5 +15,10 @@ UnitBlueprint {
         BuildCostMass = 50,
         BuildTime = 400,
     },
+    Physics = {
+    	BuildOnLayerCaps = {
+    		LAYER_Water = true,
+    	},
+    },
 
 }

--- a/mods/battle-royale/merge/units/xsc1301.bp
+++ b/mods/battle-royale/merge/units/xsc1301.bp
@@ -15,5 +15,10 @@ UnitBlueprint {
         BuildCostMass = 50,
         BuildTime = 6000,
     },
+    Physics = {
+       	BuildOnLayerCaps = {
+       		LAYER_Water = true,
+       	},
+    },
 
 }

--- a/mods/battle-royale/merge/units/xsc1501.bp
+++ b/mods/battle-royale/merge/units/xsc1501.bp
@@ -15,5 +15,9 @@ UnitBlueprint {
         BuildCostMass = 50,
         BuildTime = 2520,
     },
-
+    Physics = {
+    	BuildOnLayerCaps = {
+    		LAYER_Water = true,
+    	},
+    },
 }

--- a/mods/battle-royale/mod_info.lua
+++ b/mods/battle-royale/mod_info.lua
@@ -5,11 +5,11 @@ name = "Battle Royale"
 
 -- version of the mod as seen in the mod manager and is used by the client to know
 -- what the latest version is
-version = 10
+version = 11
 
 -- used by the client to automatically download this mod, must be unique and updated
 -- when releasing a new version
-uid = "battle-royale-10"
+uid = "battle-royale-11"
 
 copyright = "GNU-3"
 description = "This mod requires the UI mod Dear Windowing. You need to enable it separarely. Without it you will have no UI. A battle royale mod including (free of charge) care packages! This mod is maintained by the community. You can find it on the FAForever group on Github."

--- a/mods/battle-royale/modules/sim/ACUInfo.lua
+++ b/mods/battle-royale/modules/sim/ACUInfo.lua
@@ -1,17 +1,13 @@
 --- An object containing the coordinates of the death of the ACU,
 --- necessary to create a commander's beacon.
-ACUDeathCoordinates = {
-    x = 0,
-    y = 0,
-    z = 0,
-}
+ACUDeathCoordinates = { }
 
-function ACUDeathCoordinates:GetCoords()
-    return {self.x, self.y, self.z}
+--- Stores ACU death coordinates, armyIndex is needed to identify specific ACU.
+function ACUDeathCoordinates:SetCoords(armyIndex, x, y, z)
+    self[armyIndex] = {x,  y, z}
 end
 
-function ACUDeathCoordinates:SetCoords(x, y, z)
-    self.x = x
-    self.y = y
-    self.z = z
+--- Depending on armyIndex returns the ACU's death coordinates.
+function ACUDeathCoordinates:GetCoords(armyIndex)
+    return self[armyIndex]
 end


### PR DESCRIPTION
Fixed a bug where when killing two ACUs at the same time, both beacons would appear at the place of death of the last ACU.
Fixed a bug where if the commander died in the water, the beacon appeared at the seabed and not on the surface of the water.